### PR TITLE
修复更新0.10后bfd-tabs classname变化导致样式混乱的问题

### DIFF
--- a/package/Aries/src/functions/CalcManage/MyTask/index.less
+++ b/package/Aries/src/functions/CalcManage/MyTask/index.less
@@ -116,18 +116,19 @@ div.MyTaskRootDiv {
   }
 
   .cTabs{
-    .nav.nav-tabs {
-      margin-top:-40px;
+    .bfd-tabs__list {
+      margin-top:-30px;
       float: right;
       border-bottom:0px
     }
-    .nav.nav-tabs li a{
+    .bfd-tabs__list li a{
       background-color: #FFFFFF;
       margin-right: 20px;
     }
-    .nav.nav-tabs li a:hover , .nav.nav-tabs li a:focus{
+    .bfd-tabs__list li a:hover , .nav.nav-tabs li a:focus{
       background-color: #FFFFFF;
       border-bottom: 1.5px solid #00BFFF;
     }
   }
 }
+


### PR DESCRIPTION
如题

**问题样式**：
![image](https://cloud.githubusercontent.com/assets/18070336/18735180/7aa6d66e-80ae-11e6-8d9d-7797391ce4aa.png)
**正常样式**：
![image](https://cloud.githubusercontent.com/assets/18070336/18735224/d7f37fe8-80ae-11e6-850b-b27fe5205c6b.png)

