### PR TITLE
修复session过期的问题

### DIFF
--- a/Aries/Aries/settings.py
+++ b/Aries/Aries/settings.py
@@ -26,6 +26,7 @@ import os,sys
 import yaml
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.join(BASE_DIR,"middleware"))
 LOG_BASE_DIR=os.path.join(BASE_DIR.rstrip("Aries"), "log")
 FTP_LOCAL_DIR=os.path.join(BASE_DIR.rstrip("Aries"), "download/")
 
@@ -74,6 +75,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'middleware.UserSessionMiddleware',
 )
 
 ROOT_URLCONF = 'Aries.urls'

--- a/Aries/middleware/middleware.py
+++ b/Aries/middleware/middleware.py
@@ -1,0 +1,24 @@
+#encoding=utf8
+from django.shortcuts import render_to_response
+from django.http import HttpResponse
+import json
+class UserSessionMiddleware(object):
+    def process_request(self, request):
+        path = request.path
+        print path
+        response = HttpResponse()
+        if path.startswith('/static/') or path == "/login":
+            #static file type or /login
+            return None
+        if not request.user.is_authenticated():
+            if path.startswith('/api/'):
+                #api type
+                res = {}
+                res["code"] = 401
+                response.write(json.dumps(res))
+                return response
+            else:
+                 # other
+                 user = ""
+                 user = json.dumps(user)
+                 return render_to_response('index/index.html',locals())

--- a/Aries/middleware/middleware.py
+++ b/Aries/middleware/middleware.py
@@ -11,7 +11,7 @@ class UserSessionMiddleware(object):
             #static file type or /login
             return None
         if not request.user.is_authenticated():
-            if path.startswith('/api/'):
+            if path.startswith('/v1/') or path.startswith('/openstack') or path.startswith('/k8s'):
                 #api type
                 res = {}
                 res["code"] = 401


### PR DESCRIPTION
目前sirius架构采用的是前后端分离的架构。并且页面所有的跳转都是前端来控制. 所以要实现session失效的统一处理必须按照3种不同类型的请求分别做过滤处理:
1.  静态文件(*.js)和登录(/login) 类型的请求。（不用做任何处理）
2. api类型的请求( 即 ajax类型的请求.) **必须已 /v1/ 开**头 (如果session失效则返回401,前端自动跳转)。
3. 其他类型的请求( 即通过浏览器输入框类型的)。 (如果session失效则直接返回index.html。并将user置 
    为"". 前端自动跳转)
由于目前有的api类型请求设计不是以 /v1 开头。所以需要改成以 /v1 开头才行.
